### PR TITLE
Add a workaround for a bug in chrome which causes the slickgrid styleshe...

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -918,7 +918,7 @@ if (typeof Slick === "undefined") {
     }
 
     function createCssRules() {
-      $style = $("<style id='slickgrid-css-rules' type='text/css' rel='stylesheet' />").appendTo($("head"));
+      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
       var rowHeight = (options.rowHeight - cellHeightDiff);
       var rules = [
         "." + uid + " .slick-header-column { left: 1000px; }",
@@ -952,8 +952,7 @@ if (typeof Slick === "undefined") {
 
         // Workaround a bug in chrome where document.styleSheets may not contain all sheets.
         if (!stylesheet) {
-          var styleEl = $("head").find("#slickgrid-css-rules")[0];
-          stylesheet = styleEl && (styleEl.sheet || styleEl.styleSheet);
+          stylesheet = $style[0] && ($style[0].sheet || $style[0].styleSheet);
         }
 
         if (!stylesheet) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -918,7 +918,7 @@ if (typeof Slick === "undefined") {
     }
 
     function createCssRules() {
-      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
+      $style = $("<style id='slickgrid-css-rules' type='text/css' rel='stylesheet' />").appendTo($("head"));
       var rowHeight = (options.rowHeight - cellHeightDiff);
       var rules = [
         "." + uid + " .slick-header-column { left: 1000px; }",
@@ -948,6 +948,12 @@ if (typeof Slick === "undefined") {
             stylesheet = sheets[i];
             break;
           }
+        }
+
+        // Workaround a bug in chrome where document.styleSheets may not contain all sheets.
+        if (!stylesheet) {
+          var styleEl = $("head").find("#slickgrid-css-rules")[0];
+          stylesheet = styleEl && (styleEl.sheet || styleEl.styleSheet);
         }
 
         if (!stylesheet) {
@@ -1515,7 +1521,7 @@ if (typeof Slick === "undefined") {
       } else {
         $canvas[0].removeChild(cacheEntry.rowNode);
       }
-      
+
       delete rowsCache[row];
       delete postProcessedRows[row];
       renderedRows--;
@@ -2162,7 +2168,7 @@ if (typeof Slick === "undefined") {
           $canvas[0].removeChild(zombieRowNodeFromLastMouseWheelEvent);
           zombieRowNodeFromLastMouseWheelEvent = null;
         }
-        rowNodeFromLastMouseWheelEvent = rowNode;      
+        rowNodeFromLastMouseWheelEvent = rowNode;
       }
     }
 
@@ -2217,7 +2223,7 @@ if (typeof Slick === "undefined") {
             cancelEditAndSetFocus();
           } else if (e.which == 34) {
             navigatePageDown();
-            handled = true;           
+            handled = true;
           } else if (e.which == 33) {
             navigatePageUp();
             handled = true;
@@ -2774,7 +2780,7 @@ if (typeof Slick === "undefined") {
         var prevActivePosX = activePosX;
         while (cell <= activePosX) {
           if (canCellBeActive(row, cell)) {
-            prevCell = cell;  
+            prevCell = cell;
           }
           cell += getColspan(row, cell);
         }


### PR DESCRIPTION
...et to not be found.

document.styleSheets on chrome can sometimes be out of date and may not contain all stylesheets.
When this happens we resort to just querying the style element we injected and grabbing the sheet
directly off it.